### PR TITLE
refactor(db): pom 프로필 기반 MySQL 설정 제거, JNDI DataSource로 전환

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,9 +296,22 @@
         <defaultGoal>install</defaultGoal>
         <finalName>petclinic</finalName>
         <resources>
+            <!-- 1) 기본 리소스는 필터링 true 유지하되, data-access.properties는 제외 -->
             <resource>
                 <directory>${basedir}/src/main/resources</directory>
                 <filtering>true</filtering>
+                <excludes>
+                    <exclude>spring/data-access.properties</exclude>
+                </excludes>
+            </resource>
+
+            <!-- 2) data-access.properties만 필터링 false로 별도 복사 -->
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>spring/data-access.properties</include>
+                </includes>
             </resource>
         </resources>
         <testResources>
@@ -524,7 +537,7 @@
                 <db.script>mysql</db.script>
                 <jpa.database>MYSQL</jpa.database>
                 <jdbc.driverClassName>com.mysql.cj.jdbc.Driver</jdbc.driverClassName>
-                <jdbc.url>jdbc:mysql://[Change Me]:3306/petclinic?useUnicode=true</jdbc.url>
+                <jdbc.url>jdbc:mysql://ChangeMe:3306/petclinic?useUnicode=true</jdbc.url>
                 <jdbc.username>root</jdbc.username>
                 <jdbc.password>petclinic</jdbc.password>
             </properties>

--- a/src/main/resources/spring/data-access.properties
+++ b/src/main/resources/spring/data-access.properties
@@ -1,10 +1,5 @@
 # Properties file with JDBC and JPA settings.
-#
-# Applied by <context:property-placeholder location="jdbc.properties"/> from
-# various application context XML files (e.g., "applicationContext-*.xml").
-# Targeted at system administrators, to avoid touching the context XML files.
 
-# Properties that control the population of schema and data for a new data source
 jdbc.initLocation=classpath:db/${db.script}/schema.sql
 jdbc.dataLocation=classpath:db/${db.script}/data.sql
 
@@ -14,6 +9,4 @@ jdbc.driverClassName=${jdbc.driverClassName}
 jdbc.url=${jdbc.url}
 jdbc.username=${jdbc.username}
 jdbc.password=${jdbc.password}
-
-# Property that determines which database to use with an AbstractJpaVendorAdapter
 jpa.database=${jpa.database}


### PR DESCRIPTION
- 기존 pom.xml 프로필로 전달하던 DB 접속정보 제거
- 톰캣 JNDI(java:comp/env/jdbc/MyDB)로 DataSource 조회
- 이유: 비밀정보 빌드 산출물 포함 방지, 운영/로컬 설정 분리, 배포 일관성
- 영향: 로컬 실행 시 JNDI 컨텍스트 필요 (임베디드 톰캣/테스트 설정 추가 필요)